### PR TITLE
Update plate-design.mzn (calculation of num_rows_line and num_cols_line)

### DIFF
--- a/plate-design.mzn
+++ b/plate-design.mzn
@@ -94,8 +94,10 @@ int: num_cols;
 
 
 %% TODO: this could be problematic when there are multiple cell lines
-int: num_rows_line = if inner_empty_edge then floor(num_rows/horizontal_cell_lines)-2*size_empty_edge else floor((num_rows-2*size_empty_edge)/horizontal_cell_lines) endif;
-int: num_cols_line = if inner_empty_edge then floor(num_cols/vertical_cell_lines)-2*size_empty_edge else floor((num_cols-2*size_empty_edge)/vertical_cell_lines) endif;
+int: num_rows_line = floor(num_rows/horizontal_cell_lines) - floor(num_rows/horizontal_cell_lines) mod 2 - 2 * size_empty_edge * inner_empty_edge;
+int: num_cols_line = floor(num_cols/vertical_cell_lines) - floor(num_cols/vertical_cell_lines) mod 2 - 2 * size_empty_edge * inner_empty_edge; 
+%int: num_rows_line = if inner_empty_edge then floor(num_rows/horizontal_cell_lines)-2*size_empty_edge else floor((num_rows-2*size_empty_edge)/horizontal_cell_lines) endif;
+%int: num_cols_line = if inner_empty_edge then floor(num_cols/vertical_cell_lines)-2*size_empty_edge else floor((num_cols-2*size_empty_edge)/vertical_cell_lines) endif;
 %int: num_rows_line = floor(num_rows/horizontal_cell_lines)-2*size_empty_edge;
 %int: num_cols_line = floor(num_cols/vertical_cell_lines)-2*size_empty_edge;
 


### PR DESCRIPTION
Two changes to the calculation:
1. Instead of if-then-else use the single formula (theoretically more readable)

2. If the number of rows/columns in a line is odd, subtract 1 row/column from the line.

e.g. if we have, say, 48 rows in a plate and we want 5 lines in a row with 1 row as an inner empty edge then:

num_rows_line = floor(48/5) - floor(48/5) mod 2 - 2 * 1 * true = 9 - (9 mod 2) - 2 = 9 - 1 - 2 = 6 rows